### PR TITLE
modules git plib_git_left_right: properly determine remote-branch

### DIFF
--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -78,8 +78,13 @@ plib_git_left_right(){
       echo -ne "${__ref#refs/heads/}"
       unset __rev
     }
+    function _remote_branch(){
+      __remote_branch=$(\git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null) || return
+      echo -ne "${__remote_branch}"
+      unset __remote_branch
+    }
     if [[ $(plib_git_branch) != "detached" ]]; then
-      __pp_stat=$(\git rev-list --left-right --count `_branch`...`plib_git_remote_name`/`_branch` 2>/dev/null)
+      __pp_stat=$(\git rev-list --left-right --count `_branch`...`_remote_branch`)
       __pull=$(echo ${__pp_stat} | awk '{print $2}' | tr -d ' \n')
       __push=$(echo ${__pp_stat} | awk '{print $1}' | tr -d ' \n')
       [[ "$__pull" != "0" ]] && [[ "$__pull" != "" ]] && echo -n " ${__pull}${PLIB_GIT_PULL_SYM}"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Docs have been added / updated in README.md (for features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
`plib_git_left_right` fails when on a branch which is tracking a non-`origin` remote


* **What is the new behavior (if this is a feature change)?**
remote-branch is now determined with `git rev-parse --abbrev-ref --symbolic-full-name @{u}`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their configuration due to this PR?)



* **Other information**:
