### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,8 @@ use modules in your theme:
 
 ## Configurations
 
-```bash
-# customize symbols
+The library no longer formats data. You will have to make your own formating.
 
-export PLIB_GIT_ADD_SYM=+
-export PLIB_GIT_DEL_SYM=-
-export PLIB_GIT_MOD_SYM=⭑
-export PLIB_GIT_NEW_SYM=?
-
-export PLIB_GIT_PUSH_SYM=↑
-export PLIB_GIT_PULL_SYM=↓
-
-# customize colors
-
-export PLIB_GIT_TRACKED_COLOR=green
-export PLIB_GIT_UNTRACKED_COLOR=red
-```
 
 ## Contributing
 

--- a/modules/background_job.zsh
+++ b/modules/background_job.zsh
@@ -1,9 +1,5 @@
 #!/usr/bin/env zsh
 
 plib_bg_count() {
-  __jobc="`jobs | grep -v "pwd" | wc -l | tr -d ' '`";
-  if [[ "$__jobc" != 0 ]]; then
-    echo -ne "[$__jobc] "
-  fi
-  unset __jobc;
+  jobs | grep -v "pwd" | wc -l | tr -d ' \n'
 }

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -27,8 +27,8 @@ plib_git_rev(){
   git rev-parse HEAD 2>/dev/null | cut -c 1-7 | tr -d ' \n'
 }
 
-plib_git_remote_defined(){
-  if [[ ! -z "$(\git remote -v | head -1 | awk '{print $1}' | tr -d ' \n')" ]]; then
+plib_git_remote_is_defined(){
+  if [[ ! -z "$1" ]] && [[ "$(\git remote -v | grep -c $1)" -gt 0 ]]; then
     echo -ne 1
   else
     echo -ne 0

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -22,10 +22,9 @@ plib_git_branch(){
   unset __ref
 }
 
+# Gets the short SHA-1 of the current revision.
 plib_git_rev(){
-  __rev=$(\git rev-parse HEAD 2>/dev/null | cut -c 1-7)
-  echo -n "${__rev}"
-  unset __rev
+  git rev-parse HEAD 2>/dev/null | cut -c 1-7 | tr -d ' \n'
 }
 
 plib_git_remote_defined(){

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -129,7 +129,12 @@ plib_git_commit_since(){
 }
 
 plib_is_git_rebasing(){
-  [[ $(ls `\git rev-parse --git-dir` | grep rebase-apply) ]] && echo -ne 1 || echo -ne 0
+  if [[ -d "$(git rev-parse --git-path rebase-merge)" || \
+    -d "$(git rev-parse --git-path rebase-apply)" ]]; then
+    echo -n 1
+  else
+    echo -n 0
+  fi
 }
 
 plib_git_stash(){

--- a/modules/git.zsh
+++ b/modules/git.zsh
@@ -44,39 +44,54 @@ plib_git_remote_name(){
   fi
 }
 
-plib_git_dirty(){
+# For everything related to git status parsing please refer to this documentation:
+# https://git-scm.com/docs/git-status#_short_format
 
-  [[ -z "${PLIB_GIT_TRACKED_COLOR}" ]] && PLIB_GIT_TRACKED_COLOR=green
-  [[ -z "${PLIB_GIT_UNTRACKED_COLOR}" ]] && PLIB_GIT_UNTRACKED_COLOR=red
-
-  [[ -z "${PLIB_GIT_ADD_SYM}" ]] && PLIB_GIT_ADD_SYM=+
-  [[ -z "${PLIB_GIT_DEL_SYM}" ]] && PLIB_GIT_DEL_SYM=-
-  [[ -z "${PLIB_GIT_MOD_SYM}" ]] && PLIB_GIT_MOD_SYM=⭑
-  [[ -z "${PLIB_GIT_NEW_SYM}" ]] && PLIB_GIT_NEW_SYM=?
-  
-  __git_st=$(\git status --porcelain 2>/dev/null)
-  
-  __mod_t=$(echo ${__git_st} | grep '^M[A,M,D,R, ]\{1\} \|^R[A,M,D,R, ]\{1\} ' | wc -l | tr -d ' ')
-  __add_t=$(echo ${__git_st} | grep '^A[A,M,D,R, ]\{1\} ' | wc -l | tr -d ' ')
-  __del_t=$(echo ${__git_st} | grep '^D[A,M,D,R, ]\{1\} ' | wc -l | tr -d ' ')
-  
-  __mod_ut=$(echo ${__git_st} | grep '^[A,M,D,R, ]\{1\}M \|^[A,M,D,R, ]\{1\}R ' | wc -l | tr -d ' ')
-  __add_ut=$(echo ${__git_st} | grep '^[A,M,D,R, ]\{1\}A ' | wc -l | tr -d ' ')
-  __del_ut=$(echo ${__git_st} | grep '^[A,M,D,R, ]\{1\}D ' | wc -l | tr -d ' ')
-  
-  __new=$(echo ${__git_st} | grep '^?? ' | wc -l | tr -d ' ')
-
-  [[ "$__add_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f"
-  [[ "$__add_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_ADD_SYM}%f"
-  [[ "$__mod_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f"
-  [[ "$__mod_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_MOD_SYM}%f"
-  [[ "$__del_t" != "0" ]]  && echo -n " %F{$PLIB_GIT_TRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f"
-  [[ "$__del_ut" != "0" ]] && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_DEL_SYM}%f"
-  [[ "$__new" != "0" ]]    && echo -n " %F{$PLIB_GIT_UNTRACKED_COLOR}${PLIB_GIT_NEW_SYM}%f"
-
-  unset __mod_ut __new_ut __add_ut __mod_t __new_t __add_t __del
+plib_git_status(){
+  echo -n "$(\git status --porcelain 2>/dev/null)"
 }
 
+# Returns the number of staged file modifications.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_staged_mod(){
+  echo -n "$1" | grep -c '^M[A,M,D,R, ]\{1\} \|^R[A,M,D,R, ]\{1\} ' | tr -d ' '
+}
+
+# Returns the number of unstaged file modifications.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_unstaged_mod(){
+  echo -n "$1" | grep -c '^[A,M,D,R, ]\{1\}M \|^[A,M,D,R, ]\{1\}R ' | tr -d ' '
+}
+
+# Returns the number of staged file deletions.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_staged_del(){
+  echo -n "$1" | grep -c '^D[A,M,D,R, ]\{1\} ' | tr -d ' '
+}
+
+# Returns the number of unstaged file deletions.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_unstaged_del(){
+  echo -n "$1" | grep -c '^[A,M,D,R, ]\{1\}D ' | tr -d ' '
+}
+
+# Returns the number of staged new files.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_staged_add(){
+  echo -n "$1" | grep -c '^A[A,M,D,R, ]\{1\} ' | tr -d ' '
+}
+
+# Returns the number of unstaged new files.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_unstaged_add(){
+  echo -n "$1" | grep -c '^[A,M,D,R, ]\{1\}A ' | tr -d ' '
+}
+
+# Returns the number of unstaged untracked files.
+# Takes a 'git status --porcelain 2' value as argument.
+plib_git_status_new(){
+  echo -n "$1" | grep -c '^?? ' | tr -d ' '
+}
 plib_git_left_right(){
   [[ -z "${PLIB_GIT_PUSH_SYM}" ]] && PLIB_GIT_PUSH_SYM='↑'
   [[ -z "${PLIB_GIT_PULL_SYM}" ]] && PLIB_GIT_PULL_SYM='↓'

--- a/test.zsh
+++ b/test.zsh
@@ -21,8 +21,28 @@ echo -ne "plib_git_branch -> " && plib_git_branch
 echo
 echo -ne "plib_git_rev -> " && plib_git_rev
 echo
-echo -ne "plib_git_dirty -> " && plib_git_dirty
+
+# Git staus / git dirty tests
+echo "plib_git_status -> "
+STATUS="$(plib_git_status)"
+echo "$STATUS"
 echo
+echo -ne "plib_git_staged_mod -> " && plib_git_staged_mod $STATUS
+echo
+echo -ne "plib_git_unstaged_mod -> " && plib_git_unstaged_mod $STATUS
+echo
+echo -ne "plib_git_staged_del -> " && plib_git_staged_del $STATUS
+echo
+echo -ne "plib_git_unstaged_del -> " && plib_git_unstaged_del $STATUS
+echo
+echo -ne "plib_git_staged_add -> " && plib_git_staged_add $STATUS
+echo
+echo -ne "plib_git_unstaged_add -> " && plib_git_unstaged_add $STATUS
+echo
+echo -ne "plib_git_status_new -> " && plib_git_status_new $STATUS
+echo
+unset STATUS
+
 echo -ne "plib_git_left_right -> " && plib_git_left_right
 echo
 echo -ne "plib_git_commit_since -> " && plib_git_commit_since

--- a/test.zsh
+++ b/test.zsh
@@ -43,6 +43,8 @@ echo -ne "plib_git_status_new -> " && plib_git_status_new $STATUS
 echo
 unset STATUS
 
+echo -ne "plib_git_remote_is_defined -> " && plib_git_remote_is_defined remote
+echo
 echo -ne "plib_git_left_right -> " && plib_git_left_right
 echo
 echo -ne "plib_git_commit_since -> " && plib_git_commit_since


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated in README.md (for features)

## Changes
This MR removes all formating commands from the library.

Currently, it **fetches data and formats it** in a certain way that makes it difficult for calling scripts to use if the formating is unwanted.

This PR aims at making the library only **return raw data instead**.

See [this issue](https://github.com/eendroroy/alien-minimal) for more details.

## Breaking changes
This PR does introduce breaking changes as a library user will no longer have "ready to print" formatted data. 

The `plib_git_dirty` function has been broken down into smaller, more atomic, functions that return individual pieces of information without formatting.

The `plib_remote_is_defined` now takes a remote name as argument to check if the remote with said name exists.

The `plib_git_left_right` no longer formats the data and returns the raw `git rev-list --left-right --count local_branch...remote_branch` value instead. By default, it will compare against the origin/current_local_branch remote branch. But you can specify a remote name and a branch name to compare against if you have special needs. 

The `plib_bg_count` no longer formats the data and returns the number of running background job as raw data.

## Warning
[Associated alien-minimal MR](https://github.com/eendroroy/alien-minimal/pull/19) which adds all the formating that was removed from plib. Merging only one of the two MR will result in alien-minimal breaking.

## Testing

New 'tests' have been added to the **test.zsh** file. I strongly recommend you play with them to see the results.