### PR TITLE
Use 'python3' if it exists and there is no 'python'

### DIFF
--- a/modules/python.zsh
+++ b/modules/python.zsh
@@ -5,7 +5,7 @@
 __python_executable_name() {
   if command -v python3 > /dev/null;
   then
-      # if is a 'python3', use that instead
+      # if there is a 'python3', use that instead of 'python'
       # this is typical on macOS
       echo "python3"
   else

--- a/modules/python.zsh
+++ b/modules/python.zsh
@@ -1,28 +1,32 @@
 #!/usr/bin/env zsh
 
 # default is regular 'python'
-_PYTHON=python;
-if ! command -v python > /dev/null && command -v python3 > /dev/null;
-then
-    # if there *not* a 'python' but there *is* a 'python3', use that instead
-    # this is typical on macOS
-    _PYTHON=python3;
-fi
+
+__python_executable_name() {
+  if command -v python3 > /dev/null;
+  then
+      # if is a 'python3', use that instead
+      # this is typical on macOS
+      echo "python3"
+  else
+    echo "python"
+  fi
+}
 
 plib_venv(){
   [[ -n "${VIRTUAL_ENV}" ]] && echo -n "($(basename "$VIRTUAL_ENV"))"
 }
 
 plib_python_version(){
-  command -v "$_PYTHON" > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk '{print $2}' | tr -d ' \n')"
+  command -v $(__python_executable_name) > /dev/null && echo -ne "$($(__python_executable_name) --version 2>&1 | awk '{print $2}' | tr -d ' \n')"
 }
 
 plib_python_major_minor_version(){
-  command -v "$_PYTHON" > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk -F '[. ]' '{printf("%s.%s",$2,$3)}')"
+  command -v $(__python_executable_name) > /dev/null && echo -ne "$($(__python_executable_name) --version 2>&1 | awk -F '[. ]' '{printf("%s.%s",$2,$3)}')"
 }
 
 plib_python_major_version(){
-  command -v "$_PYTHON" > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk -F '[. ]' '{print $2}')"
+  command -v $(__python_executable_name) > /dev/null && echo -ne "$($(__python_executable_name) --version 2>&1 | awk -F '[. ]' '{print $2}')"
 }
 
 plib_pyenv_version(){

--- a/modules/python.zsh
+++ b/modules/python.zsh
@@ -14,7 +14,7 @@ plib_venv(){
 }
 
 plib_python_version(){
-  command -v $_PYTHON > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk '{print $2}' | tr -d ' \n')"
+  command -v "$_PYTHON" > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk '{print $2}' | tr -d ' \n')"
 }
 
 plib_python_major_minor_version(){

--- a/modules/python.zsh
+++ b/modules/python.zsh
@@ -1,19 +1,28 @@
 #!/usr/bin/env zsh
 
+# default is regular 'python'
+_PYTHON=python;
+if ! command -v python > /dev/null && command -v python3 > /dev/null;
+then
+    # if there *not* a 'python' but there *is* a 'python3', use that instead
+    # this is typical on macOS
+    _PYTHON=python3;
+fi
+
 plib_venv(){
   [[ -n "${VIRTUAL_ENV}" ]] && echo -n "($(basename "$VIRTUAL_ENV"))"
 }
 
 plib_python_version(){
-  command -v python > /dev/null && echo -ne "$(python --version 2>&1 | awk '{print $2}' | tr -d ' \n')"
+  command -v $_PYTHON > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk '{print $2}' | tr -d ' \n')"
 }
 
 plib_python_major_minor_version(){
-  command -v python > /dev/null && echo -ne "$(python --version 2>&1 | awk -F '[. ]' '{printf("%s.%s",$2,$3)}')"
+  command -v "$_PYTHON" > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk -F '[. ]' '{printf("%s.%s",$2,$3)}')"
 }
 
 plib_python_major_version(){
-  command -v python > /dev/null && echo -ne "$(python --version 2>&1 | awk -F '[. ]' '{print $2}')"
+  command -v "$_PYTHON" > /dev/null && echo -ne "$("$_PYTHON" --version 2>&1 | awk -F '[. ]' '{print $2}')"
 }
 
 plib_pyenv_version(){


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
python version not reported if python executable is 'python3'


* **What is the new behavior (if this is a feature change)?**
if `python3` exists and `python` does not, that is used instead


* **Does this PR introduce a breaking change?** (What changes might users need to make in their configuration due to this PR?)
n/a


* **Other information**:
`python3` without `python` is common on macOS
